### PR TITLE
Add image modal with zoom for cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,11 @@
       </p>
     </footer>
 
+    <!-- Image modal for enlarged card view -->
+    <div id="image-modal" class="image-modal">
+      <img id="modal-image" src="" alt="Enlarged card" />
+    </div>
+
     <!-- JavaScript to handle data loading and filtering -->
     <script src="script.js"></script>
   </body>

--- a/script.js
+++ b/script.js
@@ -7,6 +7,8 @@
 document.addEventListener('DOMContentLoaded', () => {
   const cardsSection = document.getElementById('cards-section');
   const navLinks = document.querySelectorAll('.nav-link');
+  const imageModal = document.getElementById('image-modal');
+  const modalImage = document.getElementById('modal-image');
   let cards = [];
 
   // Fetch card data from the JSON file
@@ -61,6 +63,14 @@ document.addEventListener('DOMContentLoaded', () => {
         </div>
       `;
       cardsSection.appendChild(cardElem);
+
+      // Add click handler to enlarge image
+      const img = cardElem.querySelector('img');
+      img.addEventListener('click', () => {
+        modalImage.src = img.src;
+        modalImage.classList.remove('zoomed');
+        imageModal.classList.add('show');
+      });
     });
   }
 
@@ -81,4 +91,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Set the current year in the footer
   document.getElementById('current-year').textContent = new Date().getFullYear();
+
+  // Close modal when clicked outside image
+  imageModal.addEventListener('click', () => {
+    imageModal.classList.remove('show');
+  });
+
+  // Toggle zoom on modal image
+  modalImage.addEventListener('click', event => {
+    event.stopPropagation();
+    modalImage.classList.toggle('zoomed');
+  });
 });

--- a/styles.css
+++ b/styles.css
@@ -109,3 +109,33 @@ footer a {
   color: #99c2ff;
   text-decoration: none;
 }
+
+/* Image modal */
+.image-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  display: none;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.image-modal.show {
+  display: flex;
+}
+
+.image-modal img {
+  max-width: 90%;
+  max-height: 90%;
+  cursor: zoom-in;
+  transition: transform 0.3s ease;
+}
+
+.image-modal img.zoomed {
+  transform: scale(2);
+  cursor: zoom-out;
+}


### PR DESCRIPTION
## Summary
- Make card images clickable, opening a modal with a larger version
- Enable zooming within modal for closer inspection

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_688d8dd642e88329b0e0ad17ec87f75d