### PR TITLE
feat: move Jared Goff card to sale category

### DIFF
--- a/cards.json
+++ b/cards.json
@@ -45,7 +45,7 @@
     "condition": "Mint",
     "market_value": "",
     "image_path": "jared_goff_card.jpg",
-    "category": "veteran"
+    "category": "sale"
   },
   {
     "player": "Jordan Jefferson",


### PR DESCRIPTION
## Summary
- update Jared Goff card category to `sale` so it appears in For Sale filter

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node -e "fetch('http://localhost:8000/cards.json').then(r=>r.json()).then(data=>{const sales=data.filter(c=>c.category==='sale').map(c=>c.player); console.log(sales);})"`
- `npx playwright install chromium` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688d8f01a3a0832994832a47bfd4d21f