### PR TITLE
Add Jest tests for card display logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "football-card-collection",
+  "version": "1.0.0",
+  "description": "",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -4,12 +4,79 @@
   activation and sets the current year in the footer.
 */
 
+let cards = [];
+let cardsSection =
+  typeof document !== 'undefined'
+    ? document.getElementById('cards-section')
+    : null;
+let navLinks;
+let imageModal;
+let modalImage;
+
+// Display cards based on selected category
+function displayCards(category) {
+  if (!cardsSection) return;
+
+  // Clear previous content
+  cardsSection.innerHTML = '';
+
+  // Determine which cards to show
+  let filtered;
+  if (category === 'home') {
+    filtered = cards;
+  } else {
+    filtered = cards.filter(card => card.category === category);
+  }
+
+  // Show message if no cards are available
+  if (filtered.length === 0) {
+    const message = document.createElement('p');
+    message.textContent = 'No cards available in this category.';
+    cardsSection.appendChild(message);
+    return;
+  }
+
+  // Render each card
+  filtered.forEach(card => {
+    const cardElem = document.createElement('div');
+    cardElem.classList.add('card');
+    cardElem.innerHTML = `
+      <img src="${card.image_path}" alt="${card.player} ${card.year}" />
+      <div class="card-details">
+        <h3>${card.player}</h3>
+        <p><strong>Year:</strong> ${card.year}</p>
+        <p><strong>Condition:</strong> ${card.condition}</p>
+        <p><strong>Market Value:</strong> ${card.market_value}</p>
+      </div>
+    `;
+    cardsSection.appendChild(cardElem);
+
+    // Add click handler to enlarge image if modal elements exist
+    if (imageModal && modalImage) {
+      const img = cardElem.querySelector('img');
+      img.addEventListener('click', () => {
+        modalImage.src = img.src;
+        modalImage.classList.remove('zoomed');
+        imageModal.classList.add('show');
+      });
+    }
+  });
+}
+
+// Utility setters for testing
+function setCards(data) {
+  cards = data;
+}
+
+function setCardsSection(section) {
+  cardsSection = section;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
-  const cardsSection = document.getElementById('cards-section');
-  const navLinks = document.querySelectorAll('.nav-link');
-  const imageModal = document.getElementById('image-modal');
-  const modalImage = document.getElementById('modal-image');
-  let cards = [];
+  cardsSection = document.getElementById('cards-section');
+  navLinks = document.querySelectorAll('.nav-link');
+  imageModal = document.getElementById('image-modal');
+  modalImage = document.getElementById('modal-image');
 
   // Fetch card data from the JSON file
   fetch('cards.json')
@@ -27,52 +94,6 @@ document.addEventListener('DOMContentLoaded', () => {
       console.error('Error loading cards:', err);
       cardsSection.innerHTML = '<p>Unable to load card data.</p>';
     });
-
-  // Display cards based on selected category
-  function displayCards(category) {
-    // Clear previous content
-    cardsSection.innerHTML = '';
-
-    // Determine which cards to show
-    let filtered;
-    if (category === 'home') {
-      filtered = cards;
-    } else {
-      filtered = cards.filter(card => card.category === category);
-    }
-
-    // Show message if no cards are available
-    if (filtered.length === 0) {
-      const message = document.createElement('p');
-      message.textContent = 'No cards available in this category.';
-      cardsSection.appendChild(message);
-      return;
-    }
-
-    // Render each card
-    filtered.forEach(card => {
-      const cardElem = document.createElement('div');
-      cardElem.classList.add('card');
-      cardElem.innerHTML = `
-        <img src="${card.image_path}" alt="${card.player} ${card.year}" />
-        <div class="card-details">
-          <h3>${card.player}</h3>
-          <p><strong>Year:</strong> ${card.year}</p>
-          <p><strong>Condition:</strong> ${card.condition}</p>
-          <p><strong>Market Value:</strong> ${card.market_value}</p>
-        </div>
-      `;
-      cardsSection.appendChild(cardElem);
-
-      // Add click handler to enlarge image
-      const img = cardElem.querySelector('img');
-      img.addEventListener('click', () => {
-        modalImage.src = img.src;
-        modalImage.classList.remove('zoomed');
-        imageModal.classList.add('show');
-      });
-    });
-  }
 
   // Handle navigation link clicks
   navLinks.forEach(link => {
@@ -103,3 +124,7 @@ document.addEventListener('DOMContentLoaded', () => {
     modalImage.classList.toggle('zoomed');
   });
 });
+
+if (typeof module !== 'undefined') {
+  module.exports = { displayCards, setCards, setCardsSection };
+}

--- a/script.test.js
+++ b/script.test.js
@@ -1,0 +1,44 @@
+const { displayCards, setCards, setCardsSection } = require('./script');
+
+describe('displayCards', () => {
+  let cardsSection;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<section id="cards-section"></section>';
+    cardsSection = document.getElementById('cards-section');
+    setCardsSection(cardsSection);
+    setCards([
+      {
+        category: 'rookie',
+        player: 'Player 1',
+        year: 2023,
+        condition: 'Mint',
+        market_value: '$100',
+        image_path: 'rookie.jpg'
+      },
+      {
+        category: 'veteran',
+        player: 'Player 2',
+        year: 2022,
+        condition: 'Good',
+        market_value: '$50',
+        image_path: 'veteran.jpg'
+      }
+    ]);
+  });
+
+  test("renders only rookie cards", () => {
+    displayCards('rookie');
+    const cards = cardsSection.querySelectorAll('.card');
+    expect(cards.length).toBe(1);
+    expect(cards[0].querySelector('h3').textContent).toBe('Player 1');
+  });
+
+  test("shows message when category is empty or unknown", () => {
+    displayCards('legend');
+    expect(cardsSection.textContent).toBe('No cards available in this category.');
+
+    displayCards('');
+    expect(cardsSection.textContent).toBe('No cards available in this category.');
+  });
+});


### PR DESCRIPTION
## Summary
- expose `displayCards` and helper setters for testing
- configure Jest and add basic tests for card rendering

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d8f0394b083299890a61118ca8bad