### PR TITLE
Handle image-only cards

### DIFF
--- a/cards.json
+++ b/cards.json
@@ -1,9 +1,5 @@
 [
   {
-    "player": "Tom Brady",
-    "year": 2000,
-    "condition": "Mint",
-    "market_value": "$15,000",
     "image_path": "tom_brady_card.png",
     "category": "rookie"
   },

--- a/script.js
+++ b/script.js
@@ -40,14 +40,24 @@ function displayCards(category) {
   filtered.forEach(card => {
     const cardElem = document.createElement('div');
     cardElem.classList.add('card');
+    const details = [];
+    if (card.player) details.push(`<h3>${card.player}</h3>`);
+    if (card.year) details.push(`<p><strong>Year:</strong> ${card.year}</p>`);
+    if (card.condition)
+      details.push(`<p><strong>Condition:</strong> ${card.condition}</p>`);
+    if (card.market_value)
+      details.push(`<p><strong>Market Value:</strong> ${card.market_value}</p>`);
+
+    const detailsHtml =
+      details.length > 0
+        ? `<div class="card-details">${details.join('')}</div>`
+        : '';
+
     cardElem.innerHTML = `
-      <img src="${card.image_path}" alt="${card.player} ${card.year}" />
-      <div class="card-details">
-        <h3>${card.player}</h3>
-        <p><strong>Year:</strong> ${card.year}</p>
-        <p><strong>Condition:</strong> ${card.condition}</p>
-        <p><strong>Market Value:</strong> ${card.market_value}</p>
-      </div>
+      <img src="${card.image_path}" alt="${[card.player, card.year]
+        .filter(Boolean)
+        .join(' ')}" />
+      ${detailsHtml}
     `;
     cardsSection.appendChild(cardElem);
 
@@ -72,11 +82,12 @@ function setCardsSection(section) {
   cardsSection = section;
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-  cardsSection = document.getElementById('cards-section');
-  navLinks = document.querySelectorAll('.nav-link');
-  imageModal = document.getElementById('image-modal');
-  modalImage = document.getElementById('modal-image');
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    cardsSection = document.getElementById('cards-section');
+    navLinks = document.querySelectorAll('.nav-link');
+    imageModal = document.getElementById('image-modal');
+    modalImage = document.getElementById('modal-image');
 
   // Fetch card data from the JSON file
   fetch('cards.json')
@@ -124,6 +135,7 @@ document.addEventListener('DOMContentLoaded', () => {
     modalImage.classList.toggle('zoomed');
   });
 });
+}
 
 if (typeof module !== 'undefined') {
   module.exports = { displayCards, setCards, setCardsSection };

--- a/script.test.js
+++ b/script.test.js
@@ -4,8 +4,61 @@ describe('displayCards', () => {
   let cardsSection;
 
   beforeEach(() => {
-    document.body.innerHTML = '<section id="cards-section"></section>';
-    cardsSection = document.getElementById('cards-section');
+    global.document = {
+      createElement: tag => ({
+        tagName: tag,
+        classList: { add() {} },
+        innerHTML: '',
+        textContent: '',
+        children: [],
+        appendChild(child) {
+          this.children.push(child);
+        },
+        querySelector(selector) {
+          if (selector === 'h3') {
+            const match = this.innerHTML.match(/<h3>([^<]*)<\/h3>/);
+            if (match) return { textContent: match[1] };
+          }
+          if (selector === '.card-details') {
+            return this.innerHTML.includes('class="card-details"') ? {} : null;
+          }
+          if (selector === 'img') {
+            const match = this.innerHTML.match(/<img[^>]*src="([^"]*)"[^>]*>/);
+            if (match)
+              return {
+                getAttribute: attr => (attr === 'src' ? match[1] : null),
+                addEventListener: () => {}
+              };
+          }
+          return null;
+        }
+      })
+    };
+
+    cardsSection = {
+      _innerHTML: '',
+      children: [],
+      textContent: '',
+      set innerHTML(val) {
+        this._innerHTML = val;
+        if (val === '') this.children = [];
+      },
+      get innerHTML() {
+        return this._innerHTML;
+      },
+      appendChild(child) {
+        this.children.push(child);
+        if (child.textContent) this.textContent = child.textContent;
+      },
+      querySelectorAll(selector) {
+        if (selector === '.card') return this.children;
+        return [];
+      },
+      querySelector(selector) {
+        if (selector === '.card') return this.children[0] || null;
+        return null;
+      }
+    };
     setCardsSection(cardsSection);
     setCards([
       {
@@ -40,5 +93,16 @@ describe('displayCards', () => {
 
     displayCards('');
     expect(cardsSection.textContent).toBe('No cards available in this category.');
+  });
+
+  test('renders image only when details are missing', () => {
+    setCards([
+      { category: 'rookie', image_path: 'image_only.jpg' }
+    ]);
+    displayCards('rookie');
+    const card = cardsSection.querySelector('.card');
+    expect(card).not.toBeNull();
+    expect(card.querySelector('img').getAttribute('src')).toBe('image_only.jpg');
+    expect(card.querySelector('.card-details')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Support cards that only provide an image by rendering details conditionally
- Remove metadata from the Tom Brady rookie entry
- Extend tests to cover image-only cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d952b97b08329a65a96c5f2d59c6f